### PR TITLE
no-unused-expressions vs Chai

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@
 
 module.exports = {
   extends: ["eslint:recommended", "plugin:prettier/recommended"],
-  plugins: ["prettier"],
+  plugins: ["prettier", "chai-friendly"],
   env: {
     es6: true,
     node: true
@@ -137,7 +137,8 @@ module.exports = {
     // 'no-sequences': 0,
     // 'no-throw-literal': 2, // eslint:recommended
     // 'no-unmodified-loop-condition': 0,
-    // 'no-unused-expressions': 0,
+    "no-unused-expressions": 0,
+    "chai-friendly/no-unused-expressions": 2 //
     // 'no-unused-labels': 2, // eslint:recommended
     // 'no-useless-call': 0,
     'no-useless-concat': "error",

--- a/package.json
+++ b/package.json
@@ -16,20 +16,16 @@
     "preversion": "npm install && npm run test",
     "version": "echo Nothing to see here",
     "postversion": "git push && git push --tags",
-    "deploy": "npm version patch --message \"Deployment version %s [skip ci]\" && npm publish"
+    "deploy":
+      "npm version patch --message \"Deployment version %s [skip ci]\" && npm publish"
   },
-  "files": [
-    "index.js"
-  ],
-  "keywords": [
-    "kelsus",
-    "code",
-    "quality"
-  ],
+  "files": ["index.js"],
+  "keywords": ["kelsus", "code", "quality"],
   "devDependencies": {
     "eslint": "^4.1.1",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-prettier": "^2.4.0",
+    "eslint-plugin-chai-friendly": "^0.4.1",
     "prettier": "^1.9.2"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -212,6 +212,10 @@ eslint-config-prettier@^2.9.0:
   dependencies:
     get-stdin "^5.0.1"
 
+eslint-plugin-chai-friendly@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-chai-friendly/-/eslint-plugin-chai-friendly-0.4.1.tgz#9eeb17f92277ba80bb64f0e946c6936a3ae707b4"
+
 eslint-plugin-prettier@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.4.0.tgz#85cab0775c6d5e3344ef01e78d960f166fb93aae"


### PR DESCRIPTION
This plugin overrides no-unused-expressions to make it friendly towards chai expect and should statements.

```// this
expect(foo).to.be.true;
foo.should.be.true;

// instead of this
expect(foo).to.be.true; // eslint-disable-line no-unused-expressions
foo.should.be.true; // eslint-disable-line no-unused-expressions```

https://github.com/ihordiachenko/eslint-plugin-chai-friendly